### PR TITLE
CASMCMS-7447: Update to use hsm v2

### DIFF
--- a/src/hwsyncagent/hwstatemgr/__init__.py
+++ b/src/hwsyncagent/hwstatemgr/__init__.py
@@ -28,7 +28,7 @@
 from hwsyncagent import HWSyncAgentException
 from hwsyncagent import PROTOCOL
 
-API_VERSION = 'v1'
+API_VERSION = 'v2'
 ENDPOINT = "%s://cray-smd/hsm/%s" % (PROTOCOL, API_VERSION)
 
 


### PR DESCRIPTION
## Summary and Scope

Switches to using HSM v2 since v1 is going away.  There were no changes in the data, so only the endpoint has changed.

## Issues and Related PRs

* Resolves CASMCMS-7447

## Testing

### Tested on:

  * Hela

### Test description:

Deleted a component and allowed it to be recreated.  Also compared the data from all used endpoints to confirm that there were no changes.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

