### PR TITLE
CASMCMS-7971 - update dev.cray.com addresses.

### DIFF
--- a/kubernetes/package-chart-for-testing.sh
+++ b/kubernetes/package-chart-for-testing.sh
@@ -35,5 +35,5 @@ path_to_chart=$( cd $path_to_chart >/dev/null 2>&1 && pwd )
 chart_name=$(basename $path_to_chart)
 
 docker run --rm -it -v $path_to_chart:/charts/$chart_name -v $this_dir:/packaged-dest \
-  arti.dev.cray.com/csm-internal-docker-stable-local/craypc/chartsutil:latest \
+  arti.hpc.amslabs.hpecorp.net/csm-internal-docker-stable-local/craypc/chartsutil:latest \
   /bin/sh -c "cd /charts/$chart_name && helm dep up && helm package . -d /packaged-dest"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
---trusted-host arti.dev.cray.com
 --trusted-host artifactory.algol60.net
---index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple
 --extra-index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
 -c constraints.txt
 kubernetes


### PR DESCRIPTION
## Summary and Scope

The 'dev.cray.com' domain is being retired and the servers moved to hpe domains.  This PR removes references to servers on this domain where able, and updates to the new hpe addresses where we still need to reference internal servers.  There are no real code changes - should just be pulling the same packages from different locations.

## Issues and Related PRs
* Resolves [CASMCMS-7971](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7971)

## Testing
### Tested on:
  * `Mug`

### Test description:

The new versions of all services are installed on Mug and are being left in place while Jason does Bos v2 testing to give these a complete workout.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N - left in place for 'soak' testing
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be low risk as it is just pulling the same stuff from different server addresses.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
