### PR TITLE
Revert "CASMINST-5443: Use version 2 of the csm-changelog-checker"

### DIFF
--- a/.github/workflows/csm-changelog-checker.yml
+++ b/.github/workflows/csm-changelog-checker.yml
@@ -38,4 +38,4 @@ jobs:
     )"
     steps:
       - name: Ensure changelog has changes
-        uses: Cray-HPE/.github/actions/csm-changelog-checker@v2-csm-changelog-checker
+        uses: Cray-HPE/.github/actions/csm-changelog-checker@v1-csm-changelog-checker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Spelling corrections.
 - The logging level is now controlled by a CFS option
 - Authenticate to CSM's artifactory
-- Use v2 of the csm-changelog-checker
 


### PR DESCRIPTION
## Summary and Scope

This reverts commit e0c91f0eab2b82d4dbb10c0bda9a920faf76ab8a.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-5443

## Testing

_List the environments in which these changes were tested._

### Tested on:

* Build system

### Test description:

  * It builds.

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

