### PR TITLE
CASMINST-5443: Authenticate to CSM's artifactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Convert to gitflow/gitversion.
 - Spelling corrections.
 - The logging level is now controlled by a CFS option
+- Authenticate to CSM's artifactory
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 FROM artifactory.algol60.net/docker.io/alpine:3.15 as base
 WORKDIR /app
 COPY constraints.txt requirements.txt ./
-RUN apk add --upgrade --no-cache apk-tools &&  \
+RUN --mount=type=secret,id=netrc,target=/root/.netrc apk add --upgrade --no-cache apk-tools &&  \
 	apk update && \
 	apk add --no-cache gcc g++ python3-dev musl-dev libffi-dev openssl-dev py3-pip && \
 	apk -U upgrade --no-cache && \

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -40,6 +40,7 @@ pipeline {
         NAME = "cfs-hwsync-agent"
         DESCRIPTION = "Configuration Framework Service Hardware Synchronization Agent"
         IS_STABLE = getBuildIsStable()
+	DOCKER_BUILDKIT = "1"
     }
 
     stages {

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ CHART_VERSION ?= $(shell head -1 .chart_version)
 
 HELM_UNITTEST_IMAGE ?= quintush/helm-unittest:3.3.0-0.2.5
 
+ifneq ($(wildcard ${HOME}/.netrc),)
+	DOCKER_ARGS ?= --secret id=netrc,src=${HOME}/.netrc
+endif
+
 all : runbuildprep lint image chart
 chart: chart_setup chart_package chart_test
 


### PR DESCRIPTION
Authenticate to CSM's artifactory when using pip to access CSM's csm-python-modules.

## Summary and Scope

Rebased to clean up the history.

* Resolves CASMINST-5443
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

