### PR TITLE
CASMCMS-8722: Use update_external_versions to get latest patch version of liveness Python module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Dependencies
+- Use `update_external_versions` to get latest patch version of `liveness` Python module.
+
 ## [1.9.1] - 2023-07-18
 ### Dependencies
 - Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,7 +4,7 @@ chardet==4.0.0
 google-auth==1.24.0
 idna==2.10
 kubernetes==12.0.1
-liveness==1.3.37
+liveness==0.0.0-liveness
 msgpack==1.0.2
 oauthlib==3.1.0
 pyasn1==0.4.8

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -1,0 +1,5 @@
+# This Python module is built in the k8s-liveness repository
+image: liveness
+    source: python
+    major: 1
+    minor: 4

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -23,3 +23,7 @@ tag: 0.0.0-image
 sourcefile: .docker_version
 targetfile: kubernetes/cfs-hwsync-agent/Chart.yaml
 targetfile: kubernetes/cfs-hwsync-agent/values.yaml
+
+tag: 0.0.0-liveness
+sourcefile: liveness.version
+targetfile: constraints.txt


### PR DESCRIPTION
## Summary and Scope

Now that `update_external_versions` handles Python modules, this update this repo to use it in order to grab the latest patch version of the `liveness` Python module.

(This was prompted by my noticing some cases in other repos where we are using outdated versions of our Python modules)