### PR TITLE
CASMCMS-8789: Add top level exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Parameterized HSM component discovery to filter to both Nodes and VirtualNodes during discovery.
 
+### Fixed
+- Added top level exception handling
+
 ## [1.10.0] - 2023-08-18
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit

--- a/src/hwsyncagent/__main__.py
+++ b/src/hwsyncagent/__main__.py
@@ -82,58 +82,62 @@ def main_loop():
 
     previous_members = set()
     while True:
-        # Normally, we would not sleep on our first iteration of the
-        # service, but incidentally, our first iteration fails because
-        # the istio proxy sidecar has not yet set up its routes correctly.
-        # For this reason, logic specific to skipping the sleep on the first
-        # iteration has been removed.
-        update_log_level()
-        LOGGER.debug("Querying sync interval for sleep")
-        sleep(hardware_sync_interval())
-        Timestamp()
-
-        # Query HSM for members
         try:
-            LOGGER.debug("Querying xnames from HSM")
-            members = read_all_node_xnames()
-        except HWStateManagerException:
-            LOGGER.error("Unable to query HSM member components; retrying...")
-            continue
-        new_members = members - previous_members
-        removed_members = previous_members - members
-        if new_members:
-            new_members_count = len(new_members)
-            if new_members_count <= 5:
-                LOGGER.info("%s discovered from HSM.", ', '.join(sorted(new_members)))
-            else:
-                LOGGER.info("%s discovered members from HSM.", new_members_count)
-        if removed_members:
-            removed_members_count = len(removed_members)
-            LOGGER.info("HSM no longer reporting membership for %s components...",
-                        removed_members_count)
-        previous_members = members
+            # Normally, we would not sleep on our first iteration of the
+            # service, but incidentally, our first iteration fails because
+            # the istio proxy sidecar has not yet set up its routes correctly.
+            # For this reason, logic specific to skipping the sleep on the first
+            # iteration has been removed.
+            update_log_level()
+            LOGGER.debug("Querying sync interval for sleep")
+            sleep(hardware_sync_interval())
+            Timestamp()
 
-        # Query the set of components CFS is aggregating status for
-        try:
-            LOGGER.debug("Querying CFS component IDs")
-            cfs_defined_components = read_registered_component_ids()
-        except CFSException as cfse:
-            LOGGER.info(cfse)
-            continue
-
-        # Determine which components are missing from CFS
-        missing_xnames_from_cfs = members - cfs_defined_components
-
-        # Create all missing components
-        if missing_xnames_from_cfs:
+            # Query HSM for members
             try:
-                LOGGER.debug("Creating missing components in CFS")
-                create_new_components(sorted(missing_xnames_from_cfs))
-                LOGGER.info("Registered %s new components with CFS.",
-                            len(missing_xnames_from_cfs))
+                LOGGER.debug("Querying xnames from HSM")
+                members = read_all_node_xnames()
+            except HWStateManagerException:
+                LOGGER.error("Unable to query HSM member components; retrying...")
+                continue
+            new_members = members - previous_members
+            removed_members = previous_members - members
+            if new_members:
+                new_members_count = len(new_members)
+                if new_members_count <= 5:
+                    LOGGER.info("%s discovered from HSM.", ', '.join(sorted(new_members)))
+                else:
+                    LOGGER.info("%s discovered members from HSM.", new_members_count)
+            if removed_members:
+                removed_members_count = len(removed_members)
+                LOGGER.info("HSM no longer reporting membership for %s components...",
+                            removed_members_count)
+            previous_members = members
+
+            # Query the set of components CFS is aggregating status for
+            try:
+                LOGGER.debug("Querying CFS component IDs")
+                cfs_defined_components = read_registered_component_ids()
             except CFSException as cfse:
                 LOGGER.info(cfse)
                 continue
+
+            # Determine which components are missing from CFS
+            missing_xnames_from_cfs = members - cfs_defined_components
+
+            # Create all missing components
+            if missing_xnames_from_cfs:
+                try:
+                    LOGGER.debug("Creating missing components in CFS")
+                    create_new_components(sorted(missing_xnames_from_cfs))
+                    LOGGER.info("Registered %s new components with CFS.",
+                                len(missing_xnames_from_cfs))
+                except CFSException as cfse:
+                    LOGGER.info(cfse)
+                    continue
+        except Exception as e:
+            LOGGER.exception(f"Unhandled exception: {e}")
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary and Scope

Fixes a bug where the main thread can exit when there is an unexpected exception, leaving only the heartbeat thread.  Catching all exceptions allows us to log them and still stay in the "when True" loop.

## Issues and Related PRs

* Resolves CASMCMS-8789

## Testing

### Tested on:

  * Mug

### Test description:

Verified that cfs-hwsync was functioning normally after the change.  Testing the exact error is difficult due to the rarity and fact that we don't have a consistent reproducer.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

