### PR TITLE
CASMCMS-8914: Use appropriate version of Python k8s client for CSM 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Dependencies
+- Bump `kubernetes` from 12.0.1 to 22.6.0 to match CSM 1.6 Kubernetes version
+
 ## [1.11.0] - 2023-09-29
 ### Changed
 - Parameterized HSM component discovery to filter to both Nodes and VirtualNodes during discovery.

--- a/constraints.txt
+++ b/constraints.txt
@@ -3,7 +3,8 @@ certifi==2020.12.5
 chardet==4.0.0
 google-auth==1.24.0
 idna==2.10
-kubernetes==12.0.1
+# CSM 1.6 uses Kubernetes 1.22, so use client v22.x to ensure compatability
+kubernetes==22.6.0
 liveness==0.0.0-liveness
 msgpack==1.0.5
 oauthlib==3.1.1


### PR DESCRIPTION
I noticed that some of our Python code for CSM 1.6 is pulling in non-optimal versions of the Kubernetes client library. Ideally the major version of the library should correspond to the Kubernetes version on the system, but in many cases it is not. This doesn't guarantee that there will be problems, but it's least risky to use the appropriate version.

This problem also exists in past CSM versions, but this is not the kind of thing worth backporting without additional reason, so I'll just confine my change to CSM 1.6.
