### PR TITLE
CASMCMS-9030: Bump minimum cray-services base chart version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When building unstable charts, have them point to the corresponding unstable Docker image
 - Remove Randy Kleinman from the chart maintainer list; add Mitch Harding
 
+### Dependencies
+- CASMCMS-9030: Bump minimum `cray-services` base chart version from 7.0.0 to 10.0.5
+
 ## [1.12.0] - 2024-02-22
 ### Dependencies
 - Bump `kubernetes` from 12.0.1 to 22.6.0 to match CSM 1.6 Kubernetes version

--- a/kubernetes/cfs-hwsync-agent/Chart.yaml
+++ b/kubernetes/cfs-hwsync-agent/Chart.yaml
@@ -33,7 +33,7 @@ sources:
 - https://github.com/Cray-HPE/cfs-hwsync-agent
 dependencies:
 - name: cray-service
-  version: ^7.0.0
+  version: ~10.0.5
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts/
 maintainers:
 - name: rbak-hpe


### PR DESCRIPTION
Per the PET team, we need to move up to this version in CSM 1.6 or we'll be broken. I installed this on mug and saw no problems.