### PR TITLE
CASMCMS-9190: Discard SMD components whose ID fields are blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- CASMCMS-9190: Discard SMD components whose ID fields are blank
 
 ## [1.12.3] - 2024-09-05
 ### Dependencies

--- a/src/hwsyncagent/hwstatemgr/components.py
+++ b/src/hwsyncagent/hwstatemgr/components.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -64,8 +64,11 @@ def read_all_node_xnames(component_types=None):
         LOGGER.error("Non-JSON response from HSM: %s", response.text)
         raise HWStateManagerException(jde) from jde
     try:
+        # Return the ID field for nodes which meet both of the following criteria:
+        # - ID field is not empty
+        # - Type field is in component_types
         return set([component['ID'] for component in json_body['Components']
-                    if component.get('Type', None) in component_types])
+                    if component['ID'] and component.get('Type', None) in component_types])
     except KeyError as ke:
         LOGGER.error("Unexpected API response from HSM")
         raise HWStateManagerException(ke) from ke

--- a/src/hwsyncagent/hwstatemgr/components.py
+++ b/src/hwsyncagent/hwstatemgr/components.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
[CASMTRIAGE-7462](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7462) was opened because of a problem caused when a CFS component was created whose ID field was an empty string. There are a number of aspects to this problem. This PR addresses one of them by modifying the CFS hwsync agent so that if it gets any components from SMD with blank ID fields, it will filter them out, just as it does for components whose type does not match what we want.

I tested this on mug and verified that the changes don't exclude anything else or cause other problems.