### PR TITLE
CASMCMS-9282: Bump Alpine version from 3.15 to 3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.13.0] - 2025-02-13
 ### Dependencies
 - Bump `certifi` version to resolve CVE: https://snyk.io/vuln/SNYK-PYTHON-CERTIFI-5805047
+- CASMCMS-9282: Bump Alpine version from 3.15 to 3.21, because 3.15 no longer receives security patches;
+  Use Python venv inside Docker image.
 
 ## [1.12.4] - 2024-11-06
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2022, 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,17 +22,23 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Base image
-FROM artifactory.algol60.net/docker.io/alpine:3.15 AS base
+FROM artifactory.algol60.net/docker.io/alpine:3.21 AS base
 WORKDIR /app
+ENV VIRTUAL_ENV=/app/venv
 COPY constraints.txt requirements.txt ./
-RUN --mount=type=secret,id=netrc,target=/root/.netrc apk add --upgrade --no-cache apk-tools &&  \
-	apk update && \
-	apk add --no-cache gcc g++ python3-dev musl-dev libffi-dev openssl-dev py3-pip && \
-	apk -U upgrade --no-cache && \
+RUN apk add --upgrade --no-cache apk-tools &&  \
+    apk update && \
+    apk add --no-cache gcc g++ python3 python3-dev musl-dev libffi-dev openssl-dev py3-pip && \
+    apk -U upgrade --no-cache && \
+    python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
     pip3 list --format freeze && \
-    pip3 install --no-cache-dir -U pip && \
+    pip3 install --no-cache-dir -U pip -c constraints.txt && \
     pip3 list --format freeze && \
-    pip3 install --no-cache-dir -r requirements.txt && \
+    pip3 install --no-cache-dir --disable-pip-version-check -U setuptools wheel -c constraints.txt && \
+    pip3 list --format freeze && \
+    pip3 install --no-cache-dir --disable-pip-version-check -r requirements.txt && \
     pip3 list --format freeze
 COPY src/hwsyncagent/ lib/hwsyncagent/
 
@@ -42,7 +48,7 @@ WORKDIR /app/
 COPY src/test lib/test/
 COPY docker_test_entry.sh .
 COPY test-requirements.txt .
-RUN pip3 install --no-cache-dir -r test-requirements.txt && \
+RUN pip3 install --no-cache-dir --disable-pip-version-check -r test-requirements.txt && \
     pip3 list --format freeze
 CMD [ "./docker_test_entry.sh" ]
 


### PR DESCRIPTION
Alpine 3.15 no longer receives security patches.

Moving to Alpine 3.19+ required minor Dockerfile rework to install the Python packages into a virtual environment.

I tested this on wasp and verified that it worked fine.